### PR TITLE
Adds repository field to package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.6",
   "description": "Web Mentions sender",
   "main": "./lib/webmention.js",
+  "repository": "github:remy/wm",
   "bin": {
     "wm": "./bin/wm.js",
     "webmention": "./bin/wm.js"


### PR DESCRIPTION
Adding this field means that:
 - the next release will add a link to this repo in the sidebar of https://www.npmjs.com/package/@remy/webmention (good for auditing code and creating issues)
 - the `npm repo` command is enabled
 - npm logging a warning that no repo is defined is avoided