### PR TITLE
fix: resolve unknown user agent on fetch request

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -1,11 +1,13 @@
 const { http, https } = require('follow-redirects');
+const version = require('../package.json').version;
+const headers = { 'User-Agent': `webmention.app@/${version}` };
 
 // by default timeout at 5 seconds
 function main(url, timeout = 1000 * 5) {
   return new Promise((resolve, reject) => {
     const client = url.startsWith('http:') ? http : https;
 
-    const req = client.request(url, { timeout }, res => {
+    const req = client.request(url, { timeout, headers }, res => {
       if (res.statusCode < 200 || res.statusCode >= 400) {
         reject(new Error(`Bad response ${res.statusCode} on ${url}`));
         return;


### PR DESCRIPTION
For your consideration: while recently testing webmention.app and my blog-pwa experiment, I noticed that the initial request doesn't set a User-Agent string when fetching for parsing:

![image](https://user-images.githubusercontent.com/643503/66220083-32dc9f80-e681-11e9-876b-368bf9f2795d.png)

While the spec doesn't really say what a parser request should send, the sender part of the spec says it should have a UA of 'webmention', so I cloned your existing UA from the send portion and patched the fetch to match:

![image](https://user-images.githubusercontent.com/643503/66220194-6ae3e280-e681-11e9-86ae-0d7081f17ee3.png)

"fix" is probably a strong word; it's more of a tiny patch. :-)