### PR TITLE
Handle webmentions between two sites on the same host

### DIFF
--- a/lib/webmention.js
+++ b/lib/webmention.js
@@ -63,7 +63,7 @@ class Webmention extends EventEmitter {
     const ignoreOwn = permalink => curr => {
       if (!this.url) return true;
       const host = parse(this.url).hostname;
-      if (curr.includes(host) || curr.includes(host + '/')) {
+      if (curr.includes(host)) {
         return false;
       }
 

--- a/lib/webmention.js
+++ b/lib/webmention.js
@@ -1,5 +1,5 @@
 const EventEmitter = require('events');
-const parse = require('url').parse;
+const url = require('url');
 const links = require('./links').links;
 const getEndpoints = require('./get-wm-endpoints');
 const request = require('./request');
@@ -62,8 +62,15 @@ class Webmention extends EventEmitter {
 
     const ignoreOwn = permalink => curr => {
       if (!this.url) return true;
-      const host = parse(this.url).hostname;
-      if (curr.includes(host)) {
+      const { hostname, pathname } = url.parse(this.url);
+      const currWithHostAndPathOnly = url.format({
+        hostname,
+        pathname: deslash(pathname),
+      });
+      const urlWithoutLastSlash = deslash(this.url);
+      // If this.url is https://myhost.com/a/, reject http://myhost.com/a and myhost.com/a/1,
+      // but not myhost.com/b.
+      if (currWithHostAndPathOnly.startsWith(urlWithoutLastSlash)) {
         return false;
       }
 
@@ -175,6 +182,13 @@ class Webmention extends EventEmitter {
       this.emit('end');
     });
   }
+}
+
+function deslash(path) {
+  if (path.endsWith('/')) {
+    return path.slice(0, -1);
+  }
+  return path;
 }
 
 module.exports = Webmention;

--- a/lib/webmention.js
+++ b/lib/webmention.js
@@ -14,6 +14,7 @@ class Webmention extends EventEmitter {
     super();
 
     this.url = null;
+    this.urlHostAndPath = null;
     this.limit = limit;
     this.send = send;
     this.__sending = false;
@@ -62,15 +63,10 @@ class Webmention extends EventEmitter {
 
     const ignoreOwn = permalink => curr => {
       if (!this.url) return true;
-      const { hostname, pathname } = url.parse(this.url);
-      const currWithHostAndPathOnly = url.format({
-        hostname,
-        pathname: deslash(pathname),
-      });
-      const urlWithoutLastSlash = deslash(this.url);
+      const currWithHostAndPathOnly = getHostAndPathFromURL(curr);
       // If this.url is https://myhost.com/a/, reject http://myhost.com/a and myhost.com/a/1,
       // but not myhost.com/b.
-      if (currWithHostAndPathOnly.startsWith(urlWithoutLastSlash)) {
+      if (currWithHostAndPathOnly.startsWith(this.urlHostAndPath)) {
         return false;
       }
 
@@ -132,6 +128,7 @@ class Webmention extends EventEmitter {
     request(url)
       .then(({ content, responseUrl }) => {
         this.url = responseUrl;
+        this.urlHostAndPath = getHostAndPathFromURL(this.url);
         this.emit('request', this.url);
         return this.load(content);
       })
@@ -182,6 +179,14 @@ class Webmention extends EventEmitter {
       this.emit('end');
     });
   }
+}
+
+function getHostAndPathFromURL(urlString) {
+  const { hostname, pathname } = url.parse(urlString);
+  return url.format({
+    hostname,
+    pathname: deslash(pathname),
+  });
 }
 
 function deslash(path) {


### PR DESCRIPTION
This is for the case in which the site at `somehostingsite.com/user-a` mentions a post on the site a `somehostingsite.com/user-b`.

The update to `ignoreOwn` takes the things being compared — the page (`this.url`) and the link being considered `curr` — and on both, tosses out everything except for the host and path. It compares them. If the link (`currWithHostAndPathOnly`) contains the page's site (`this.urlHostAndPath`), it considers the link part of the site.

But if the link has the same host, but does not contain the page's url within it, it does not reject it.