### PR TITLE
Add 'syndication' as link type to receive webmention.

### DIFF
--- a/lib/microformat/dom.js
+++ b/lib/microformat/dom.js
@@ -70,6 +70,7 @@ async function dom(html, { url, limit }) {
         'bookmark-of',
         'mention-of',
         'rsvp',
+	'syndication',
       ];
 
       types.forEach(type => {


### PR DESCRIPTION
Sites like https://indieweb.xyz and
https://news.indieweb.org use a webmention sent
for a link with "u-syndication" indicated, see:
https://indieweb.xyz/howto/en
and
https://news.indieweb.org/how-to-submit-a-post
It's possible that this would be a good moment
to reexamine whether there are other classes of
link that merit inclusion here, but this change
is limited to what I know would be useful for a
user of the service (i.e., me).

---

I think this might be my first Github PR? Please let me know if there's anything I can do to make this an acceptable change. 