### PR TITLE
add webmention documentation

### DIFF
--- a/pages/docs/index.vue
+++ b/pages/docs/index.vue
@@ -9,6 +9,20 @@
       <code>hentry</code>) Microformat markup, RSS and Atom. For backward compatibility both webmention and pingback protocols are supported.
     </p>
 
+    <details id="what-is-a-webmention">
+      <summary>
+        <h2>What is a webmention</h2>
+      </summary>
+      <div>
+        <p>
+          A webmention is a web standard that allows sites to notify each other of links.
+          Sites can make use of these notifications to display comments, count likes, or link back to the source page.
+          To learn more about what you can do with webmentions, visit the <a href="https://indieweb.org/Webmention">IndieWeb wiki</a>.
+        </p>
+
+      </div>
+    </details>
+
     <details id="send-webmentions-using-the-web-service">
       <summary>
         <h2>Send webmentions using the web service</h2>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -3,7 +3,11 @@
     <h1>webmention.app</h1>
     <h2>Automate your outgoing webmentions</h2>
     <div class="flex-grow">
-      <p>This is a platform agnostic service that will check a given URL for links to other sites, discover if they support webmentions, then send a webmention to the target.</p>
+      <p>
+        This is a platform agnostic service that will check a given URL for links to other sites, discover if they support
+        <a href="https://indieweb.org/Webmention">webmentions</a>,
+        then send a webmention to the target.
+      </p>
 
       <p>The notification API is reasonably simplistic:</p>
 


### PR DESCRIPTION
Adds some links to the IndieWeb wiki page for webmentions to help people discover why the tool exists and how webmentions can be used.

closes #33