### PR TITLE
Exit with status code 1 if no endpoints found

### DIFF
--- a/bin/wm.js
+++ b/bin/wm.js
@@ -88,6 +88,8 @@ if (!send) {
       } else {
         console.log('No webmention endpoints found');
       }
+
+      process.exit(1);
     }
 
     res.map((res) => {


### PR DESCRIPTION
This allows people to write the following kind of code:

```sh
if  wm "$1" && prompt -y "Send mentions for these URLs?"; then
    wm "$1" --send
fi
```

Instead of this monstrosity:

```sh
out="$(wm "$1")"
echo "$out"

if [ "$out" != "No webmention endpoints found on 1 entries found (try increasing with --limit N)" ] && prompt -y "Send mentions for these URLs?"; then
  wm "$1" --send
fi
```

